### PR TITLE
fixed readme; this is a pull request test of Julia's REPL interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ A simpler example is
   opt_filter, divmin = threaded_extractor(prob, CMAES(ftol=1e-20, cov_scale=10))
   
   #plot the results
-  triptic(img, opt_filter)
+  triptic(image, opt_filter)
 ```
 
 ### Image Evaluation


### PR DESCRIPTION
`README.md` had `img` instead of `image` in part of the example code. 