### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,7 @@ Optim = "0.20, 0.21, 0.22, 1.0, 1.1, 1.2"
 Parameters = "0.12"
 RecipesBase = "1.0"
 Requires = "1.1"
-SpecialFunctions = "0.10, 1.0"
+SpecialFunctions = "0.10, 1.0, 2"
 julia = "1.4,1.5,1.6"
 
 [extras]


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` this shouldn't affect you.