### PR TITLE
Upgrade HDF5 and `import DataFrames: stack` to avoid a clash?

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VIDA"
 uuid = "4096cdfb-f084-40a3-b02d-1a2a54920cb8"
 authors = ["Paul Tiede <ptiede91@gmail.com>"]
-version = "0.10.7"
+version = "0.10.8"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
@@ -29,7 +29,7 @@ CMAEvolutionStrategy = "0.1,0.2"
 DataFrames = "0.19, 0.20, 0.21, 0.22, 1.0"
 DocStringExtensions = "0.8"
 FITSIO = "0.14, 0.15, 0.16"
-HDF5 = "0.14, 0.15"
+HDF5 = "0.14, 0.15, 0.16"
 ImageFiltering = "0.6"
 Interpolations = "0.12, 0.13"
 LaTeXStrings = "1.1"

--- a/src/VIDA.jl
+++ b/src/VIDA.jl
@@ -26,6 +26,8 @@ using RecipesBase
 using Requires
 using SpecialFunctions:erf
 
+import DataFrames: stack  # ensure two exports don't clash; also exported by Base julia 1.9.
+
 export
     #make the divergences to use for optimization
     Bhattacharyya, KullbackLeibler, LeastSquares,Renyi,


### PR DESCRIPTION
I don't know anything about this package but tests now pass locally.

The reason for suggesting this change is that Base exports `stack` from 1.9, creating a clash:
> WARNING: both VIDA and Base export "stack"; uses of it in module Test_templates must be qualified

In fact DataFrames also exports `stack`, so there may already be a clash if those are used together. Recent versions of DataFrames extend the function from Compat / Base to avoid this, and this package depends on DataFrames, so an obvious solution would be to import and extend that: Then this package needs no new deps. 

But latest DataFrames wants Compat 4, and this wants HDF5 0.15, which wants Compat 3. So this PR proposes to, first, allow HDF5 v0.16. I don't know what the changed or whether it matters:  https://github.com/JuliaIO/HDF5.jl/releases/tag/v0.16.0 
```
(jl_Xpc1Gh) pkg> st
Status `/private/var/folders/yq/4p2zwd614y59gszh7y9ypyhh0000gn/T/jl_Xpc1Gh/Project.toml`
  [34da2185] Compat v4.3.0
  [a93c6f00] DataFrames v1.4.1
  [f67ccb44] HDF5 v0.16.12
  [4096cdfb] VIDA v0.10.8 `https://github.com/mcabbott/VIDA.jl#patch-1`
```
The method defined here is for a type this package owns, so this is not piracy:
```
julia> @which VIDA.stack
VIDA

julia> methods(VIDA.stack)
# 1 method for generic function "stack" from VIDA:
 [1] stack(θ::T, θ1...) where T<:VIDA.AbstractTemplate
     @ ~/.julia/packages/VIDA/B7joP/src/templates/composite.jl:58

julia> @which VIDA.AbstractTemplate
VIDA
```
https://github.com/ptiede/VIDA.jl/blob/e161a11b07b1cac5272f708b1f663fd582a34e99/src/templates/composite.jl#L58-L60

And looking at the other methods, there is no reason to expect ambiguities:
```
julia> methods(stack)
# 6 methods for generic function "stack" from Base:
 [1] stack(df::AbstractDataFrame)
     @ DataFrames ~/.julia/packages/DataFrames/Lrd7K/src/abstractdataframe/reshape.jl:136
 [2] stack(df::AbstractDataFrame, measure_vars)
     @ DataFrames ~/.julia/packages/DataFrames/Lrd7K/src/abstractdataframe/reshape.jl:136
 [3] stack(df::AbstractDataFrame, measure_vars, id_vars; variable_name, value_name, view, variable_eltype)
     @ DataFrames ~/.julia/packages/DataFrames/Lrd7K/src/abstractdataframe/reshape.jl:136
 [4] stack(iter; dims)
     @ abstractarray.jl:2719
 [5] stack(f, iter; dims)
     @ abstractarray.jl:2748
 [6] stack(f, xs, yzs...; dims)
     @ abstractarray.jl:2749
```
Also, the earliest DataFrames version listed does already contain (and export) this function. 